### PR TITLE
Addition of a constraint in RequiredAttributes/Extref,

### DIFF
--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/RequiredAttributes/ExtRef.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/RequiredAttributes/ExtRef.ocl
@@ -140,6 +140,13 @@ context ExtRef
         )
     :
         self.pDO <> null implies self.validSclFullDOName( pDO )
+  
+  	-- In an "ExtRef", if a LN is mapped and "lnClass" is different from "LLN0", the attribute "lnInst" should be present   
+      inv ExtRef_lnInst_notNull_whenNotLLN0
+        ( 'ERROR:[RequiredAttributes] lnInst attribute is mandatory when lnClass is different from LLNO (line ' + self.lineNumber.toString() + '). '
+        )
+    :
+        self.lnClass <> null implies (self.lnClass <> 'LLN0' implies self.lnInst <> null)
 
 
 endpackage


### PR DESCRIPTION
Correction of the issue :
https://github.com/riseclipse/riseclipse-ocl-constraints-scl2003/issues/2#issue-591187577

In an "ExtRef", if a LN is mapped and "lnClass" is different from
"LLN0", the attribute "lnInst" should be present.