### PR TITLE
Remove warnings in ocl constraints

### DIFF
--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/AbstractConductingEquipment.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/AbstractConductingEquipment.ocl
@@ -23,14 +23,14 @@ import scl: 'http://www.iec.ch/61850/2003/SCL'
 
 package scl
 
-context PowerTransformer
-        
-    -- The SubEquipment in PowerTransformer shall have unique child name (from SCL_Substation.xsd)
-    inv PowerTransformer_unique_name_of_SubEquipment
+context AbstractConductingEquipment
+
+    -- The SubEquipment in AbstractConductingEquipment shall have unique child name (from SCL_Substation.xsd)
+    inv AbstractConductingEquipment_unique_name_of_SubEquipment
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/PowerTransformer_unique_name_of_SubEquipment;'
+          + 'OCL/SemanticConstraints/AbstractConductingEquipment_unique_name_of_SubEquipment;'
           + self.lineNumber.toString() + ';'
-          + 'Unique child name of SubEquipment in PowerTransformer'
+          + 'Unique child name of SubEquipment in AbstractConductingEquipment'
         )
     :
         self.SubEquipment -> isUnique( n : Naming | n.name )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/AbstractDataObject.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/AbstractDataObject.ocl
@@ -26,9 +26,9 @@ package scl
 context AbstractDataObject
 
     -- a AbstractDataObject must refer an existing DOType
-    inv Control_RefersToDataSet
+    inv AbstractDataObject_RefersToDataSet
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/Control_RefersToDataSet;'
+          + 'OCL/SemanticConstraints/AbstractDataObject_RefersToDataSet;'
           + self.lineNumber.toString() + ';'
           + 'DO or SDO (name=' + self.name.toString() + ')  does not refer an existing DOType in DataTypeTemplates section'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/AnyLN.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/AnyLN.ocl
@@ -26,9 +26,9 @@ package scl
 context AnyLN
 
     --  The name of the log control block shall be unique within the LN.
-    inv LN_LogControl_name_unique
+    inv AnyLN_LogControl_name_unique
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/LN_LogControl_name_unique;'
+          + 'OCL/SemanticConstraints/AnyLN_LogControl_name_unique;'
           + self.lineNumber.toString() + ';'
           + 'name of the log control block shall be unique within the AnyLN'
         )
@@ -36,9 +36,9 @@ context AnyLN
         self.LogControl -> isUnique( l : LogControl | l.name )
 
     -- The name of the report control block shall be unique within the LN.
-    inv LN_ReportControl_name_unique
+    inv AnyLN_ReportControl_name_unique
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/LN_ReportControl_name_unique;'
+          + 'OCL/SemanticConstraints/AnyLN_ReportControl_name_unique;'
           + self.lineNumber.toString() + ';'
           + 'name of the report control block shall be unique within the AnyLN'
         )
@@ -46,9 +46,9 @@ context AnyLN
         self.ReportControl -> isUnique( r: ReportControl | r.name )
 
     -- The Log element has as its only attribute its name, which shall be unique within the LN.
-    inv LN_Log_name_unique
+    inv AnyLN_Log_name_unique
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/LN_Log_name_unique;'
+          + 'OCL/SemanticConstraints/AnyLN_Log_name_unique;'
           + self.lineNumber.toString() + ';'
           + 'name of the Log shall be unique within the AnyLN'
         )
@@ -56,9 +56,9 @@ context AnyLN
         self.Log -> isUnique( l : Log | l.name ) 
 
     -- In DOI.name: "Its value must be unique at this level, i.e. there shall be at maximum one DOI element for the same data object."
-    inv LN_DOI_name_unique
+    inv AnyLN_DOI_name_unique
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/LN_DOI_name_unique;'
+          + 'OCL/SemanticConstraints/AnyLN_DOI_name_unique;'
           + self.lineNumber.toString() + ';'
           + 'name of the DOI shall be unique within the AnyLN'
         )
@@ -67,9 +67,9 @@ context AnyLN
     
 
     -- The lnClass in LN or LN must be the same as the referenced LNodeType lnClass
-    inv LNodeType_lnClass_consistent
+    inv AnyLN_LNodeType_lnClass_consistent
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/LNodeType_lnClass_consistent;'
+          + 'OCL/SemanticConstraints/AnyLN_LNodeType_lnClass_consistent;'
           + self.lineNumber.toString() + ';'
           + 'lnClass shall be the same as the referenced LNodeType lnClass'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/BDA.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/BDA.ocl
@@ -32,9 +32,9 @@ context BDA
     --    self.oclContainer.oclIsTypeOf(DOType) implies self.ProtNs -> isUnique( p : ProtNs | p.type )
         
     -- BDA.type is allowed only if bType = Struct or Enum
-    inv BDAType_allowedWhen_Enum
+    inv BDA_BDAType_allowedWhen_Enum
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/BDAType_allowedWhen_Enum;'
+          + 'OCL/SemanticConstraints/BDA_BDAType_allowedWhen_Enum;'
           + self.lineNumber.toString() + ';'
           + 'BDA.type is allowed only if bType = Struct or Enum'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/ClientLN.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/ClientLN.ocl
@@ -36,31 +36,31 @@ context ClientLN
         self.RefersToAnyLN <> null    
    
      
-   	-- Checks that the IED sending the Report is connected to the same subNetwork that the receiver IED
+    -- Checks that the IED sending the Report is connected to the same subNetwork that the receiver IED
      inv ClientLN_Sender_and_receiver_not_in_same_subnetwork
-		(   'ERROR;'
+        (   'ERROR;'
           + 'OCL/SemanticConstraints/ClientLN_Sender_and_receiver_not_in_same_subnetwork;'
           + self.lineNumber.toString() + ';'
           + 'Sender and receiver of the Report are not in the same Subnetwork'
         )
     :
- 			if (self.ParentRptEnabled.ParentReportControl.ParentAnyLN.oclIsTypeOf(LN0))
-  			then (
-			self.ParentRptEnabled.ParentReportControl.ParentAnyLN.oclAsType(LN0).ParentLDevice.ParentServer.ParentAccessPoint.ReferredByConnectedAP.ParentSubNetwork.ConnectedAP
-  				  				-> select (c : ConnectedAP | c.iedName = self.iedName and (if self.apRef <> null then c.apName = self.apRef else true endif)) 
-  				  				-> size() = 1
-  			)
-  			else(
-  				if (self.ParentRptEnabled.ParentReportControl.ParentAnyLN.oclIsTypeOf(LN))
-  				then (
-				self.ParentRptEnabled.ParentReportControl.ParentAnyLN.oclAsType(LN).ParentLDevice.ParentServer.ParentAccessPoint.ReferredByConnectedAP.ParentSubNetwork.ConnectedAP
-  				  				-> select (c : ConnectedAP | c.iedName = self.iedName and (if self.apRef <> null then c.apName = self.apRef else true endif)) 
-  				  				-> size() = 1
-  				)
-  				else true			
-  				endif
-  			)
-  			endif
+            if (self.ParentRptEnabled.ParentReportControl.ParentAnyLN.oclIsTypeOf(LN0))
+            then (
+            self.ParentRptEnabled.ParentReportControl.ParentAnyLN.oclAsType(LN0).ParentLDevice.ParentServer.ParentAccessPoint.ReferredByConnectedAP.ParentSubNetwork.ConnectedAP
+                                -> select (c : ConnectedAP | c.iedName = self.iedName and (if self.apRef <> null then c.apName = self.apRef else true endif)) 
+                                -> size() = 1
+            )
+            else(
+                if (self.ParentRptEnabled.ParentReportControl.ParentAnyLN.oclIsTypeOf(LN))
+                then (
+                self.ParentRptEnabled.ParentReportControl.ParentAnyLN.oclAsType(LN).ParentLDevice.ParentServer.ParentAccessPoint.ReferredByConnectedAP.ParentSubNetwork.ConnectedAP
+                                -> select (c : ConnectedAP | c.iedName = self.iedName and (if self.apRef <> null then c.apName = self.apRef else true endif)) 
+                                -> size() = 1
+                )
+                else true           
+                endif
+            )
+            endif
 
 endpackage
 

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/ClientLN.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/ClientLN.ocl
@@ -25,49 +25,6 @@ package scl
 
 context ClientLN
 
-    -- iedName definition: "The name of the IED where the LN resides"
-    inv iedName_consistency
-        (   'ERROR;'
-          + 'OCL/SemanticConstraints/iedName_consistency;'
-          + self.lineNumber.toString() + ';'
-          + 'iedName from ClientLN shall be the name of the IED containing the referred LN'
-        )
-    :
-        if self.iedName <> null and self.RefersToAnyLN <> null then 
-        if self.RefersToAnyLN.oclContainer.oclIsTypeOf(LDevice) then 
-            self.RefersToAnyLN.oclContainer.oclContainer.oclContainer.oclContainer -> collect(i:IED|i.name).matches(self.iedName)
-                -> includes(true)
-        else self.RefersToAnyLN.oclContainer.oclContainer -> collect(i:IED|i.name).matches(self.iedName) -> includes(true)
-        endif else true endif
-        
-    -- ldInst definition: "The instance identification of the LD where the LN resides"
-    inv ldInst_consistency
-        (   'ERROR;'
-          + 'OCL/SemanticConstraints/ldInst_consistency;'
-          + self.lineNumber.toString() + ';'
-          + 'ldInst from ClientLN shall be the inst of the LDevice containing the referred LN'
-        )
-    :
-        if self.ldInst <> null and self.RefersToAnyLN <> null then 
-        if self.RefersToAnyLN.oclContainer.oclIsTypeOf(LDevice) then 
-            self.RefersToAnyLN.oclContainer -> collect(l:LDevice|l.inst).matches(self.ldInst)
-                -> includes(true)
-        else true
-        endif else true endif
-
-    -- prefix definition: "The LN prefix"
-    inv perfix_consistency
-        (   'ERROR;'
-          + 'OCL/SemanticConstraints/perfix_consistency;'
-          + self.lineNumber.toString() + ';'
-          + 'prefix from ClientLN shall be the prefix of the referred LN'
-        )
-    :
-        if self.prefix <> null and self.RefersToAnyLN <> null then 
-            self.RefersToAnyLN -> collect(l:LN|l.prefix).matches(self.prefix)
-                -> includes(true)
-        else true endif
-        
     -- a ClientLN must refer an existing LN
     inv ClientLN_RefersToLNodeType
         (   'ERROR;'

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/ConductingEquipment.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/ConductingEquipment.ocl
@@ -75,9 +75,9 @@ context ConductingEquipment
         endif
         
     -- The ConductingEquipment in Bay shall have unique name in SubEquipment, EqFunction (from SCL_Substation.xsd)
-    inv unique_name_in_ConductingEquipment_from_Bay
+    inv ConductingEquipment_unique_name_from_Bay
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_ConductingEquipment_from_Bay;'
+          + 'OCL/SemanticConstraints/ConductingEquipment_unique_name_from_Bay;'
           + self.lineNumber.toString() + ';'
           + 'Unique SubEquipment, EqFunction name in ConductingEquipment from Bay'
         )
@@ -86,9 +86,9 @@ context ConductingEquipment
         self.SubEquipment -> union(self.EqFunction) -> isUnique(n:Naming|n.name)
         
     -- The ConductingEquipment in Function shall have unique name in SubEquipment, EqFunction (from SCL_Substation.xsd)
-    inv unique_name_in_ConductingEquipment_from_Function
+    inv ConductingEquipment_unique_name_from_Function
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_ConductingEquipment_from_Function;'
+          + 'OCL/SemanticConstraints/ConductingEquipment_unique_name_from_Function;'
           + self.lineNumber.toString() + ';'
           + 'Unique SubEquipment, EqFunction name in ConductingEquipment from Function'
         )
@@ -97,9 +97,9 @@ context ConductingEquipment
         self.SubEquipment -> union(self.EqFunction) -> isUnique(n:Naming|n.name)
         
     -- The ConductingEquipment in SubFunction shall have unique name in SubEquipment (from SCL_Substation.xsd)
-    inv unique_name_in_ConductingEquipment_from_SubFunction
+    inv ConductingEquipment_unique_name_from_SubFunction
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_ConductingEquipment_from_SubFunction;'
+          + 'OCL/SemanticConstraints/ConductingEquipment_unique_name_from_SubFunction;'
           + self.lineNumber.toString() + ';'
           + 'Unique SubEquipment name in ConductingEquipment from SubFunction'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/ConnectedAP.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/ConnectedAP.ocl
@@ -37,9 +37,9 @@ context ConnectedAP
         self.iedName <> null implies scl.IED->exists( i : IED | i.name = self.iedName )
         
     -- The ConnectedAP in SubNetwork shall have unique GSE cbName and ldInst (from SCL_Communication.xsd)
-    inv unique_attributes_combination_GSE_in_ConnectedAP_from_SubNetwork
+    inv ConnectedAP_unique_attributes_combination_GSE_from_SubNetwork
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_attributes_combination_GSE_in_ConnectedAP_from_SubNetwork;'
+          + 'OCL/SemanticConstraints/ConnectedAP_unique_attributes_combination_GSE_from_SubNetworkk;'
           + self.lineNumber.toString() + ';'
           + 'Unique GSE cbName and ldInst combination in ConnectedAP from SubNetwork'
         )
@@ -47,9 +47,9 @@ context ConnectedAP
         self.oclContainer.oclIsTypeOf(SubNetwork) implies self.GSE -> isUnique( g : GSE | Sequence{ g.cbName , g.ldInst } )
 
     -- The ConnectedAP in SubNetwork shall have unique SMV cbName and ldInst (from SCL_Communication.xsd)
-    inv unique_attributes_combination_SMV_in_ConnectedAP_from_SubNetwork
+    inv ConnectedAP_unique_attributes_combination_SMV_from_SubNetwork
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_attributes_combination_SMV_in_ConnectedAP_from_SubNetwork;'
+          + 'OCL/SemanticConstraints/ConnectedAP_unique_attributes_combination_SMV_from_SubNetwork;'
           + self.lineNumber.toString() + ';'
           + 'Unique SMV cbName and ldInst combination in ConnectedAP from SubNetwork'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/DA.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/DA.ocl
@@ -26,9 +26,9 @@ package scl
 context DA
 
     -- The DA in DOType shall have unique ProtNs type (from SCL_DataTypeTemplates.xsd)
-    inv unique_ProtNs_type_in_DA_from_DOType
+    inv DA_unique_ProtNs_type_in_DA_from_DOType
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_ProtNs_type_in_DA_from_DOType;'
+          + 'OCL/SemanticConstraints/DA_unique_ProtNs_type_in_DA_from_DOType;'
           + self.lineNumber.toString() + ';'
           + 'Unique ProtNs type in DA from DOType'
         )
@@ -36,9 +36,9 @@ context DA
         self.oclContainer.oclIsTypeOf(DOType) implies self.ProtNs -> isUnique( p : ProtNs | p.type )
         
     -- DA.type is allowed only if bType = Struct or Enum
-    inv DAType_allowedWhen_Enum
+    inv DA_DAType_allowedWhen_Enum
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/DAType_allowedWhen_Enum;'
+          + 'OCL/SemanticConstraints/DA_DAType_allowedWhen_Enum;'
           + self.lineNumber.toString() + ';'
           + 'DA.type is allowed only if bType = Struct or Enum'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/DAType.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/DAType.ocl
@@ -26,9 +26,9 @@ package scl
 context DAType
 
     -- The DAType in DataTypeTemplates shall have unique BDA name (from SCL_DataTypeTemplates.xsd)
-    inv unique_BDA_name_in_DAType_from_DataTypeTemplates
+    inv DAType_unique_BDA_name_in_DAType_from_DataTypeTemplates
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_BDA_name_in_DAType_from_DataTypeTemplates;'
+          + 'OCL/SemanticConstraints/DAType_unique_BDA_name_from_DataTypeTemplates;'
           + self.lineNumber.toString() + ';'
           + 'Unique BDA name in DAType from DataTypeTemplates'
         )
@@ -37,9 +37,9 @@ context DAType
         self.BDA -> isUnique(b:BDA|b.name)
         
     -- The DAType in DataTypeTemplates shall have unique ProtNs type (from SCL_DataTypeTemplates.xsd)
-    inv unique_ProtNs_type_in_DAType_from_DataTypeTemplates
+    inv DAType_unique_ProtNs_type_in_DAType_from_DataTypeTemplates
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_ProtNs_type_in_DAType_from_DataTypeTemplates;'
+          + 'OCL/SemanticConstraints/DAType_unique_ProtNs_type_from_DataTypeTemplates;'
           + self.lineNumber.toString() + ';'
           + 'Unique ProtNs type in DAType from DataTypeTemplates'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/DOI.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/DOI.ocl
@@ -34,15 +34,9 @@ context DOI
         )
     :
        let dai = self.DAI -> collect( d : DAI | Tuple{ ix:Integer=d.ix, name:String=d.name } ),
-           sdi = self.SDI -> collect( s : SDI | Tuple{ ix:Integer=s.ix, name:String=s.name } ),
-           all = dai -> includingAll( sdi )
+           sdi = self.SDI -> collect( s : SDI | Tuple{ ix:Integer=s.ix, name:String=s.name } )
        in
-       -- Does not work: the double iterators version will pick the same element for s1 and s2
-       --all -> forAll( s1, s2 | s1 <> s2 )
-       -- Does not work: s1 <> s2 compares tuple values, not tuple identity
-       --all -> forAll( s1, s2 | s1 <> s2 implies s1.ix <> s2.ix or s1.name <> s2.name )
-       -- So let's compare the size of the bag and the size of the set
-       all->size() = all->asSet()->size()
+       dai -> includingAll( sdi ) -> isUnique( ix_name_tuple | ix_name_tuple )
        
     -- The DOI in AnyLN must have a reference to a DO, that is, the AnyLN that contains the DOI must reference a valid LNType
     -- The consistency of the reference is already established in AnyLNImpl.java

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/DOI.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/DOI.ocl
@@ -26,18 +26,23 @@ package scl
 context DOI
         
     -- The DOI in AnyLN shall have unique DAI and SDI ix and name combination (from SCL_IED.xsd)
-    inv unique_DAI_SDI_ix_name_in_DOI_from_AnyLN
+    inv DOI_unique_DAI_SDI_ix_name_in_DOI_from_AnyLN
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_DAI_SDI_ix_name_in_DOI_from_AnyLN;'
+          + 'OCL/SemanticConstraints/DOI_unique_DAI_SDI_ix_name_in_DOI_from_AnyLN;'
           + self.lineNumber.toString() + ';'
           + 'Unique DAI and SDI ix and name combination in DOI from AnyLN'
         )
     :
-       let dai = self.DAI -> collect(d : DAI | Sequence{d.ix, d.name}) -> asOrderedSet() -> asBag()
-       ,
-       sdi = self.SDI -> collect(s : SDI | Sequence{s.ix, s.name}) -> asOrderedSet() -> asBag()
+       let dai = self.DAI -> collect( d : DAI | Tuple{ ix:Integer=d.ix, name:String=d.name } ),
+           sdi = self.SDI -> collect( s : SDI | Tuple{ ix:Integer=s.ix, name:String=s.name } ),
+           all = dai -> includingAll( sdi )
        in
-       self.oclContainer.oclIsKindOf(AnyLN) implies dai -> union(sdi) -> isUnique(s:SclObject | s)
+       -- Does not work: the double iterators version will pick the same element for s1 and s2
+       --all -> forAll( s1, s2 | s1 <> s2 )
+       -- Does not work: s1 <> s2 compares tuple values, not tuple identity
+       --all -> forAll( s1, s2 | s1 <> s2 implies s1.ix <> s2.ix or s1.name <> s2.name )
+       -- So let's compare the size of the bag and the size of the set
+       all->size() = all->asSet()->size()
        
     -- The DOI in AnyLN must have a reference to a DO, that is, the AnyLN that contains the DOI must reference a valid LNType
     -- The consistency of the reference is already established in AnyLNImpl.java

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/DOType.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/DOType.ocl
@@ -70,9 +70,9 @@ context DOType
         self.checkRecursiveReferenced( Set{ self.id } ).ok
         
     -- The DOType in DataTypeTemplates shall have unique child name (from SCL_DataTypeTemplates.xsd)
-    inv unique_child_name_in_DOType_from_DataTypeTemplates
+    inv DOType_unique_child_name_from_DataTypeTemplates
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_child_name_in_DOType_from_DataTypeTemplates;'
+          + 'OCL/SemanticConstraints/DOType_unique_child_name_from_DataTypeTemplates;'
           + self.lineNumber.toString() + ';'
           + 'Unique child name in DOType from DataTypeTemplates'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/DOType.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/DOType.ocl
@@ -27,7 +27,7 @@ context DOType
 
     -- Recursive references are not allowed
     def: getReferencedDOTypeIDs() : Set( String ) =
-        self.SDO->iterate( s : SDO, res : Set( String ) = Set{} |
+        self.SDO->iterate( s : SDO; res : Set( String ) = Set{} |
             res->including( s.type )
         )
     
@@ -42,7 +42,7 @@ context DOType
         endif endif
     
     def: checkRecursiveReferenced( current : Set( String )) : Tuple( ok : Boolean, set : Set( String )) =
-        let newIDs  : Set( String ) = current->iterate( s : String, res : Set( String ) = Set{} |
+        let newIDs  : Set( String ) = current->iterate( s : String; res : Set( String ) = Set{} |
             let doType : DOType = self.getReferencedDOType( s ) in
             if( doType.oclIsInvalid() ) then
                 invalid
@@ -78,7 +78,7 @@ context DOType
         )
     :
         self.oclContainer.oclIsTypeOf(DataTypeTemplates) implies
-        self.DA.name -> union(self.SDO.name) -> isUnique(s:SclObject|s)
+        self.DA.name -> union( self.SDO.name ) -> isUnique( name | name )
         
 
 endpackage

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/DataTypeTemplates.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/DataTypeTemplates.ocl
@@ -33,7 +33,11 @@ context DataTypeTemplates
           + 'Unique child id from DataTypeTemplates'
         )
     :
-        self.oclContents -> isUnique(i : IDNaming | i.id)
+                  self.LNodeType-> collect( i : IDNaming | i.id )
+         ->union( self.DOType   -> collect( i : IDNaming | i.id ))
+         ->union( self.DAType   -> collect( i : IDNaming | i.id ))
+         ->union( self.EnumType -> collect( i : IDNaming | i.id ))
+         -> isUnique( id | id )
         
     
 

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/DataTypeTemplates.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/DataTypeTemplates.ocl
@@ -26,9 +26,9 @@ package scl
 context DataTypeTemplates
 
     -- The children of DataTypeTemplates shall have unique id (from SCL_DataTypeTemplates.xsd)
-    inv unique_child_id_from_DataTypeTemplates
+    inv DataTypeTemplates_unique_child_id
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_child_id_from_DataTypeTemplates;'
+          + 'OCL/SemanticConstraints/DataTypeTemplates_unique_child_id;'
           + self.lineNumber.toString() + ';'
           + 'Unique child id from DataTypeTemplates'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/EnumType.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/EnumType.ocl
@@ -26,9 +26,9 @@ package scl
 context EnumType
 
     -- The EnumType in DataTypeTemplates shall have unique EnumType (from SCL_DataTypeTemplates.xsd)
-    inv unique_EnumVal_ord_in_EnumType_from_DataTypeTemplates
+    inv EnumType_unique_EnumVal_ord_in_from_DataTypeTemplates
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_EnumVal_ord_in_EnumType_from_DataTypeTemplates;'
+          + 'OCL/SemanticConstraints/EnumType_unique_EnumVal_ord_from_DataTypeTemplates;'
           + self.lineNumber.toString() + ';'
           + 'Unique EnumVal ord in EnumType from DataTypeTemplates'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/GSE.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/GSE.ocl
@@ -43,11 +43,11 @@ context GSE
                 self.Address.P->isUnique( p : P | p.type )
             else   -- R-GOOSE
                 true
-            endif            	
+            endif
         else
             true
         endif
-    
+
 
 endpackage
 

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/GeneralEquipment.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/GeneralEquipment.ocl
@@ -33,7 +33,8 @@ context GeneralEquipment
           + 'Unique child name in GeneralEquipment from Function'
         )
     :
-        self.oclContainer.oclIsTypeOf(Function) implies self.oclContents -> isUnique(n:Naming|n.name)
+        self.oclContainer.oclIsTypeOf( Function ) implies
+        self.oclContainer.oclAsType  ( Function ) -> isUnique( n:Naming | n.name )
         
     -- The GeneralEquipment in SubFunction shall have unique child name (from SCL_Substation.xsd)
     inv GeneralEquipment_unique_name_from_SubFunction
@@ -43,7 +44,8 @@ context GeneralEquipment
           + 'Unique child name in GeneralEquipment from SubFunction'
         )
     :
-        self.oclContainer.oclIsTypeOf(SubFunction) implies self.oclContents -> isUnique(n:Naming|n.name)
+        self.oclContainer.oclIsTypeOf( SubFunction ) implies
+        self.oclContainer.oclAsType  ( SubFunction ) -> isUnique( n:Naming | n.name )
         
     -- The GeneralEquipment in AbstractEqFuncSubFunc shall have unique child name (from SCL_Substation.xsd)
     inv GeneralEquipment_unique_name_from_AbstractEqFuncSubFunc
@@ -53,7 +55,8 @@ context GeneralEquipment
           + 'Unique child name in GeneralEquipment from AbstractEqFuncSubFunc'
         )
     :
-        self.oclContainer.oclIsKindOf(AbstractEqFuncSubFunc) implies self.oclContents -> isUnique(n:Naming|n.name)
+        self.oclContainer.oclIsKindOf( AbstractEqFuncSubFunc ) implies
+        self.oclContainer.oclAsType  ( AbstractEqFuncSubFunc ) -> isUnique( n:Naming | n.name )
         
     -- The GeneralEquipment in GeneralEquipmentContainer shall have unique child name (from SCL_Substation.xsd)
     inv GeneralEquipment_unique_name_from_GeneralEquipmentContainer
@@ -63,7 +66,8 @@ context GeneralEquipment
           + 'Unique child name in GeneralEquipment from GeneralEquipmentContainer'
         )
     :
-        self.oclContainer.oclIsKindOf(GeneralEquipmentContainer) implies self.oclContents -> isUnique(n:Naming|n.name)
+        self.oclContainer.oclIsKindOf( GeneralEquipmentContainer ) implies
+        self.oclContainer.oclAsType  ( GeneralEquipmentContainer ) -> isUnique( n:Naming | n.name )
         
     -- The GeneralEquipment in EquipmentContainer shall have unique child name (from SCL_Substation.xsd)
     inv GeneralEquipment_unique_name_from_EquipmentContainer
@@ -73,7 +77,8 @@ context GeneralEquipment
           + 'Unique child name in GeneralEquipment from EquipmentContainer'
         )
     :
-        self.oclContainer.oclIsKindOf(EquipmentContainer) implies self.oclContents -> isUnique(n:Naming|n.name)
+        self.oclContainer.oclIsKindOf( EquipmentContainer ) implies
+        self.oclContainer.oclAsType  ( EquipmentContainer ) -> isUnique( n:Naming | n.name )
 
 
 endpackage

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/GeneralEquipment.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/GeneralEquipment.ocl
@@ -26,9 +26,9 @@ package scl
 context GeneralEquipment
         
     -- The GeneralEquipment in Function shall have unique child name (from SCL_Substation.xsd)
-    inv unique_name_in_GeneralEquipment_from_Function
+    inv GeneralEquipment_unique_name_from_Function
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_GeneralEquipment_from_Function;'
+          + 'OCL/SemanticConstraints/GeneralEquipment_unique_name_from_Function;'
           + self.lineNumber.toString() + ';'
           + 'Unique child name in GeneralEquipment from Function'
         )
@@ -36,9 +36,9 @@ context GeneralEquipment
         self.oclContainer.oclIsTypeOf(Function) implies self.oclContents -> isUnique(n:Naming|n.name)
         
     -- The GeneralEquipment in SubFunction shall have unique child name (from SCL_Substation.xsd)
-    inv unique_name_in_GeneralEquipment_from_SubFunction
+    inv GeneralEquipment_unique_name_from_SubFunction
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_GeneralEquipment_from_SubFunction;'
+          + 'OCL/SemanticConstraints/GeneralEquipment_unique_name_from_SubFunction;'
           + self.lineNumber.toString() + ';'
           + 'Unique child name in GeneralEquipment from SubFunction'
         )
@@ -46,9 +46,9 @@ context GeneralEquipment
         self.oclContainer.oclIsTypeOf(SubFunction) implies self.oclContents -> isUnique(n:Naming|n.name)
         
     -- The GeneralEquipment in AbstractEqFuncSubFunc shall have unique child name (from SCL_Substation.xsd)
-    inv unique_name_in_GeneralEquipment_from_AbstractEqFuncSubFunc
+    inv GeneralEquipment_unique_name_from_AbstractEqFuncSubFunc
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_GeneralEquipment_from_AbstractEqFuncSubFunc;'
+          + 'OCL/SemanticConstraints/GeneralEquipment_unique_name_from_AbstractEqFuncSubFunc;'
           + self.lineNumber.toString() + ';'
           + 'Unique child name in GeneralEquipment from AbstractEqFuncSubFunc'
         )
@@ -56,9 +56,9 @@ context GeneralEquipment
         self.oclContainer.oclIsKindOf(AbstractEqFuncSubFunc) implies self.oclContents -> isUnique(n:Naming|n.name)
         
     -- The GeneralEquipment in GeneralEquipmentContainer shall have unique child name (from SCL_Substation.xsd)
-    inv unique_name_in_GeneralEquipment_from_GeneralEquipmentContainer
+    inv GeneralEquipment_unique_name_from_GeneralEquipmentContainer
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_GeneralEquipment_from_GeneralEquipmentContainer;'
+          + 'OCL/SemanticConstraints/GeneralEquipment_unique_name_from_GeneralEquipmentContainer;'
           + self.lineNumber.toString() + ';'
           + 'Unique child name in GeneralEquipment from GeneralEquipmentContainer'
         )
@@ -66,9 +66,9 @@ context GeneralEquipment
         self.oclContainer.oclIsKindOf(GeneralEquipmentContainer) implies self.oclContents -> isUnique(n:Naming|n.name)
         
     -- The GeneralEquipment in EquipmentContainer shall have unique child name (from SCL_Substation.xsd)
-    inv unique_name_in_GeneralEquipment_from_EquipmentContainer
+    inv GeneralEquipment_unique_name_from_EquipmentContainer
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_GeneralEquipment_from_EquipmentContainer;'
+          + 'OCL/SemanticConstraints/GeneralEquipment_unique_name_from_EquipmentContainer;'
           + self.lineNumber.toString() + ';'
           + 'Unique child name in GeneralEquipment from EquipmentContainer'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/IED.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/IED.ocl
@@ -66,9 +66,9 @@ context IED
         endif
  
     -- The FCDA shall refer to LDevice in the same IED (from SCL_IED.ocl)       
-    inv FCDA_in_LN_refers_LDevice_in_same_IED
+    inv IED_FCDA_in_LN_refers_LDevice_in_same_IED
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/FCDA_in_LN_refers_LDevice_in_same_IED;'
+          + 'OCL/SemanticConstraints/IED_FCDA_in_LN_refers_LDevice_in_same_IED;'
           + self.lineNumber.toString() + ';'
           + 'FCDA in IED shall reference LDevice in the same IED via ldInst'
         )
@@ -88,9 +88,9 @@ context IED
             else true endif
         else true endif
 
-    inv FCDA_in_LN0_refers_LDevice_in_same_IED
+    inv IED_FCDA_in_LN0_refers_LDevice_in_same_IED
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/FCDA_in_LN0_refers_LDevice_in_same_IED;'
+          + 'OCL/SemanticConstraints/IED_FCDA_in_LN0_refers_LDevice_in_same_IED;'
           + self.lineNumber.toString() + ';'
           + 'FCDA in IED shall reference LDevice in the same IED via ldInst'
         )
@@ -111,9 +111,9 @@ context IED
         else true endif
         
     -- The ServerAt shall refer to AccessPoint in the same IED (from SCL_IED.ocl)
-    inv ServerAt_refers_AccessPoint_in_same_IED
+    inv IED_ServerAt_refers_AccessPoint_in_same_IED
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/ServerAt_refers_AccessPoint_in_same_IED;'
+          + 'OCL/SemanticConstraints/IED_ServerAt_refers_AccessPoint_in_same_IED;'
           + self.lineNumber.toString() + ';'
           + 'ServerAt in IED shall reference AccessPoint in the same IED via ldInst'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/IEDName.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/IEDName.ocl
@@ -30,39 +30,39 @@ context IEDName
     -- check that for a SampledValueControl/IEDName -> the correct Input/ExtRef are created (ERROR because SICS S381 is mandatory see 61850-6 ed2.1)
 
     inv IEDName_not_declared_as_ExtRef
-		(   'ERROR;'
+        (   'ERROR;'
           + 'OCL/SemanticConstraints/IEDName_not_declared_as_ExtRef;'
           + self.lineNumber.toString() + ';'
           + 'IEDName has no corresponding ExtRef in the receiver IED'
         )
     :
-   		self.RefersToAnyLN <> null
-	
+        self.RefersToAnyLN <> null
+    
    -- Checks that the IED sending the GOOSE or the SV is connected to the same subNetwork that the receiver IED
      inv IEDName_Sender_and_receiver_not_in_same_subnetwork
-		(   'ERROR;'
+        (   'ERROR;'
           + 'OCL/SemanticConstraints/IEDName_Sender_and_receiver_not_in_same_subnetwork;'
           + self.lineNumber.toString() + ';'
           + 'Sender and receiver are not in the same Subnetwork'
         )
     :
-  		if (self.ParentControlWithIEDName.oclIsTypeOf(SampledValueControl) )
-  			then
-			( self.ParentControlWithIEDName.oclAsType(SampledValueControl).ParentLN0.ParentLDevice.ParentServer.ParentAccessPoint.ReferredByConnectedAP.ParentSubNetwork.ConnectedAP
-  				  				-> select (c : ConnectedAP | c.iedName = self.value and c.apName = self.apRef) 
-  				  				-> size() = 1
-  			)
-  		else (
-  			if (self.ParentControlWithIEDName.oclIsTypeOf(GSEControl))
-  			then
-  			( self.ParentControlWithIEDName.oclAsType(GSEControl).ParentLN0.ParentLDevice.ParentServer.ParentAccessPoint.ReferredByConnectedAP.ParentSubNetwork.ConnectedAP
-  				  				-> select (c : ConnectedAP | c.iedName = self.value and c.apName = self.apRef) 
-  				  				-> size() = 1
-  			)
-  			else true
-  			endif			
-  		)
-  		endif
+        if (self.ParentControlWithIEDName.oclIsTypeOf(SampledValueControl) )
+            then
+            ( self.ParentControlWithIEDName.oclAsType(SampledValueControl).ParentLN0.ParentLDevice.ParentServer.ParentAccessPoint.ReferredByConnectedAP.ParentSubNetwork.ConnectedAP
+                                -> select (c : ConnectedAP | c.iedName = self.value and c.apName = self.apRef) 
+                                -> size() = 1
+            )
+        else (
+            if (self.ParentControlWithIEDName.oclIsTypeOf(GSEControl))
+            then
+            ( self.ParentControlWithIEDName.oclAsType(GSEControl).ParentLN0.ParentLDevice.ParentServer.ParentAccessPoint.ReferredByConnectedAP.ParentSubNetwork.ConnectedAP
+                                -> select (c : ConnectedAP | c.iedName = self.value and c.apName = self.apRef) 
+                                -> size() = 1
+            )
+            else true
+            endif           
+        )
+        endif
 
 
 endpackage

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/LDevice.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/LDevice.ocl
@@ -27,9 +27,9 @@ context LDevice
 
     -- The ldName, if specified, must be unique within each SubNetwork
     
-    inv Unique_LDevice_ldName
+    inv LDevice_Unique_ldName
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/Unique_LDevice_ldName;'
+          + 'OCL/SemanticConstraints/LDevice_Unique_ldName;'
           + self.lineNumber.toString() + ';'
           + 'ldName attribute in LDevice must be unique within each Subnetwork'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/LN.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/LN.ocl
@@ -99,7 +99,5 @@ context LN
     :
         self.Log -> isUnique(l:Log|l.name)
 
-inv:true
-
 endpackage
 

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/LN.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/LN.ocl
@@ -30,9 +30,9 @@ context LN
     -- The name of the report control block shall be unique within the LN: in AnyLN
     
     -- The ReportControl in LN shall have unique name (from SCL_IED.xsd)
-    inv unique_name_in_ReportControl_from_LN
+    inv LN_unique_name_in_ReportControl
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_ReportControl_from_LN;'
+          + 'OCL/SemanticConstraints/LN_unique_name_in_ReportControl;'
           + self.lineNumber.toString() + ';'
           + 'Unique name in ReportControl from LN'
         )
@@ -40,9 +40,9 @@ context LN
         self.ReportControl -> isUnique(c:ReportControl|c.name)
         
     -- The ReportControl in LN shall have unique datSet (from SCL_IED.xsd)
-    inv unique_datSet_in_ReportControl_from_LN
+    inv LN_unique_datSet_in_ReportControl
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_datSet_in_ReportControl_from_LN;'
+          + 'OCL/SemanticConstraints/LN_unique_datSet_in_ReportControl;'
           + self.lineNumber.toString() + ';'
           + 'Unique datSet in ReportControl from LN'
         )
@@ -50,9 +50,9 @@ context LN
         self.ReportControl -> isUnique(c:ReportControl|c.datSet)
         
     -- The LogControl in LN shall have unique name (from SCL_IED.xsd)
-    inv unique_name_in_LogControl_from_LN
+    inv LN_unique_name_in_LogControl
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_LogControl_from_LN;'
+          + 'OCL/SemanticConstraints/LN_unique_name_in_LogControl;'
           + self.lineNumber.toString() + ';'
           + 'Unique name in LogControl from LN'
         )
@@ -60,9 +60,9 @@ context LN
         self.LogControl -> isUnique(c:LogControl|c.name)
 
     -- The LogControl in LN shall have unique datSet (from SCL_IED.xsd)
-    inv unique_datSet_in_LogControl_from_LN
+    inv LN_unique_datSet_in_LogControl
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_datSet_in_LogControl_from_LN;'
+          + 'OCL/SemanticConstraints/LN_unique_datSet_in_LogControl;'
           + self.lineNumber.toString() + ';'
           + 'Unique datSet in LogControl from LN'
         )
@@ -70,9 +70,9 @@ context LN
         self.LogControl -> isUnique(c:LogControl|c.datSet)
         
     -- The DataSet in LN shall have unique name (from SCL_IED.xsd)
-    inv unique_name_in_DataSet_from_LN
+    inv LN_unique_name_in_DataSet
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_DataSet_from_LN;'
+          + 'OCL/SemanticConstraints/LN_unique_name_in_DataSet;'
           + self.lineNumber.toString() + ';'
           + 'Unique name in DataSet from LN'
         )
@@ -80,9 +80,9 @@ context LN
         self.DataSet -> isUnique(d:DataSet|d.name)
         
     -- The DOI in LN shall have unique name (from SCL_IED.xsd)
-    inv unique_name_in_DOI_from_LN
+    inv LN_unique_name_in_DOI
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_DOI_from_LN;'
+          + 'OCL/SemanticConstraints/LN_unique_name_in_DOI;'
           + self.lineNumber.toString() + ';'
           + 'Unique name in DOI from LN'
         )
@@ -90,9 +90,9 @@ context LN
         self.DOI -> isUnique(d:DOI|d.name)
         
     -- The Log in LN shall have unique name (from SCL_IED.xsd)
-    inv unique_name_in_Log_from_LN
+    inv LN_unique_name_in_Log
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_Log_from_LN;'
+          + 'OCL/SemanticConstraints/LN_unique_name_in_Log;'
           + self.lineNumber.toString() + ';'
           + 'Unique name in Log from LN'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/LN0.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/LN0.ocl
@@ -50,9 +50,9 @@ context LN0
         self.SampledValueControl -> isUnique( c : SampledValueControl | c.name )
         
     -- The ReportControl in LN0 shall have unique name (from SCL_IED.xsd)
-    inv unique_name_in_ReportControl_from_LN0
+    inv LN0_name_in_ReportControl
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_ReportControl_from_LN0;'
+          + 'OCL/SemanticConstraints/LN0_name_in_ReportControl;'
           + self.lineNumber.toString() + ';'
           + 'Unique name in ReportControl from LN0'
         )
@@ -61,9 +61,9 @@ context LN0
         
         
     -- The LogControl in LN0 shall have unique name (from SCL_IED.xsd)
-    inv unique_name_in_LogControl_from_LN0
+    inv LN0_name_in_LogControl
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_LogControl_from_LN0;'
+          + 'OCL/SemanticConstraints/LN0_name_in_LogControl;'
           + self.lineNumber.toString() + ';'
           + 'Unique name in LogControl from LN0'
         )
@@ -72,9 +72,9 @@ context LN0
         
 
     -- The DataSet in LN0 shall have unique name (from SCL_IED.xsd)
-    inv unique_name_in_DataSet_from_LN0
+    inv LN0_name_in_DataSet
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_DataSet_from_LN0;'
+          + 'OCL/SemanticConstraints/LN0_name_in_DataSet;'
           + self.lineNumber.toString() + ';'
           + 'Unique name in DataSet from LN0'
         )
@@ -82,9 +82,9 @@ context LN0
         self.DataSet -> isUnique(d:DataSet|d.name)
         
     -- The DOI in LN0 shall have unique name (from SCL_IED.xsd)
-    inv unique_name_in_DOI_from_LN0
+    inv LN0_name_in_DOI
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_DOI_from_LN0;'
+          + 'OCL/SemanticConstraints/LN0_name_in_DOI;'
           + self.lineNumber.toString() + ';'
           + 'Unique name in DOI from LN0'
         )
@@ -92,9 +92,9 @@ context LN0
         self.DOI -> isUnique(d:DOI|d.name)
         
     -- The Log in LN0 shall have unique name (from SCL_IED.xsd)
-    inv unique_name_in_Log_from_LN0
+    inv LN0_name_in_Log
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_Log_from_LN0;'
+          + 'OCL/SemanticConstraints/LN0_name_in_Log;'
           + self.lineNumber.toString() + ';'
           + 'Unique name in Log from LN0'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/LNode.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/LNode.ocl
@@ -83,9 +83,9 @@ context LNode
      -- If the logical node is later allocated to an IED within an SCD, 
      -- then the value of this lnType attribute can be ignored, or may be used to check if 
      -- the logical node type used on the IED fulfills the requirements.
-    inv lnType_consistencyDO
+    inv LNode_lnType_consistencyDO
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/lnType_consistencyDO;'
+          + 'OCL/SemanticConstraints/LNode_lnType_consistencyDO;'
           + self.lineNumber.toString() + ';'
           + 'lnType in LNode specifies something different from what is implemented in the IED : missing DO or SDO'
         )
@@ -101,9 +101,9 @@ context LNode
             else true endif
         else true endif
 
-    inv lnType_consistencyDA
+    inv LNode_lnType_consistencyDA
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/lnType_consistencyDA;'
+          + 'OCL/SemanticConstraints/LNode_lnType_consistencyDA;'
           + self.lineNumber.toString() + ';'
           + 'lnType in LNode specifies something different from what is implemented in the IED : different parameters'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/LNodeType.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/LNodeType.ocl
@@ -26,9 +26,9 @@ package scl
 context LNodeType
 
     -- The LNodeType in DataTypeTemplates shall have unique DO name (from SCL_DataTypeTemplates.xsd)
-    inv unique_DO_name_in_LNodeType_from_DataTypeTemplates
+    inv LNodeType_unique_DO_name_from_DataTypeTemplates
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_DO_name_in_LNodeType_from_DataTypeTemplates;'
+          + 'OCL/SemanticConstraints/LNodeType_unique_DO_name_from_DataTypeTemplates;'
           + self.lineNumber.toString() + ';'
           + 'Unique DO name in LNodeTYpe from DataTypeTemplates'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/Line.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/Line.ocl
@@ -41,38 +41,6 @@ context Line
         --in let childs_3 : OrderedSet( Naming ) = childs_2->union( self.PowerTransformer )
         --in let childs_4 : OrderedSet( Naming ) = childs_3->union( self.VoltageLevel )
         --in childs_4->isUnique( n : Naming | n.name )
-        
-        
-    -- each contained element shall have a unique name        
-    inv Line_unique_name_same_level
-        (   'ERROR;'
-          + 'OCL/SemanticConstraints/Line_unique_name_same_level;'
-          + self.lineNumber.toString() + ';'
-          + 'All names shall be unique at each hierarchy level within the Line'
-        )
-    :   
-        if self.ParentSCL <> null then
-        SclObject.allInstances()->
-        select(s:SclObject|self.ParentSCL.oclContents()->
-            select(s:SclObject|s.lineNumber>self.lineNumber)->
-            forAll(s1:SclObject|s1.lineNumber>s.lineNumber) 
-            and s.lineNumber>self.lineNumber)->
-            select(s:SclObject|s.oclIsKindOf(Naming))->
-            exists(n1:Naming;n2:Naming|n1<>n2 
-                and n1.oclContainer=n2.oclContainer 
-                and n1.name=n2.name) implies false
-        else
-        SclObject.allInstances()->
-        select(s:SclObject|self.ParentProcess.oclContents()->
-            select(s:SclObject|s.lineNumber>self.lineNumber)->
-            forAll(s1:SclObject|s1.lineNumber>s.lineNumber) 
-            and s.lineNumber>self.lineNumber)->
-            select(s:SclObject|s.oclIsKindOf(Naming))->
-            exists(n1:Naming;n2:Naming|n1<>n2 
-                and n1.oclContainer=n2.oclContainer 
-                and n1.name=n2.name) implies false
-        endif
-    
 
 endpackage
 

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/Line.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/Line.ocl
@@ -44,9 +44,9 @@ context Line
         
         
     -- each contained element shall have a unique name        
-    inv unique_name_same_level_in_Line
+    inv Line_unique_name_same_level
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_same_level_in_Line;'
+          + 'OCL/SemanticConstraints/Line_unique_name_same_level;'
           + self.lineNumber.toString() + ';'
           + 'All names shall be unique at each hierarchy level within the Line'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/LogControl.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/LogControl.ocl
@@ -46,7 +46,7 @@ context LogControl
           + 'LogControl does not refer an existing Log'
         )
     :
-        self.RefersToLog <> null            
+        self.RefersToLog <> null
             
             
             

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/PowerTansformer.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/PowerTansformer.ocl
@@ -26,9 +26,9 @@ package scl
 context PowerTransformer
         
     -- The PowerTransformer in EquipmentContainer shall have unique child name (from SCL_Substation.xsd)
-    inv unique_name_in_PowerTransformer_from_EquipmentContainer
+    inv PowerTransformer_unique_name_from_EquipmentContainer
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_PowerTransformer_from_EquipmentContainer;'
+          + 'OCL/SemanticConstraints/PowerTransformer_unique_name_from_EquipmentContainer;'
           + self.lineNumber.toString() + ';'
           + 'Unique child name in PowerTransformer from EquipmentContainer'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/PowerTansformer.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/PowerTansformer.ocl
@@ -25,16 +25,8 @@ package scl
 
 context PowerTransformer
         
-    -- The PowerTransformer in EquipmentContainer shall have unique child name (from SCL_Substation.xsd)
-    inv PowerTransformer_unique_name_from_EquipmentContainer
-        (   'ERROR;'
-          + 'OCL/SemanticConstraints/PowerTransformer_unique_name_from_EquipmentContainer;'
-          + self.lineNumber.toString() + ';'
-          + 'Unique child name in PowerTransformer from EquipmentContainer'
-        )
-    :
-        self.oclContainer.oclIsKindOf(EquipmentContainer) implies self.oclContents -> isUnique(n:Naming|n.name)
-
+    inv PowerTransformer_nothing:
+        true
 
 endpackage
 

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/Process.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/Process.ocl
@@ -61,31 +61,5 @@ context Process
         --in let childs_4 : OrderedSet( Naming ) = childs_3->union( self.VoltageLevel )
         --in childs_4->isUnique( n : Naming | n.name )
     
-    -- TODO: Process elements at different levels in a hierarchy branch, 
-    -- which have a type defined, should have different types. 
-    -- Any exceptions shall be explicitly defined for this usage.  
-    
-    -- In general, at each hierarchy level within the Process section all names shall be
-    -- unique, leading to unique object references (path names) of all objects defined by the
-    -- substation naming hierarchy.
-    inv Process_unique_name_same_level
-        (   'ERROR;'
-          + 'OCL/SemanticConstraints/Process_unique_name_same_level;'
-          + self.lineNumber.toString() + ';'
-          + 'All names shall be unique at each hierarchy level within the Process'
-        )
-    :   
-        self.ParentSCL <> null implies
-        (SclObject.allInstances()->
-        select(s:SclObject|self.ParentSCL.oclContents()->
-            select(s:SclObject|s.lineNumber>self.lineNumber)->
-            forAll(s1:SclObject|s1.lineNumber>s.lineNumber) 
-            and s.lineNumber>self.lineNumber)->
-            select(s:SclObject|s.oclIsKindOf(Naming))->
-            exists(n1:Naming;n2:Naming|n1<>n2 
-                and n1.oclContainer=n2.oclContainer 
-                and n1.name=n2.name) implies false)
-
-
 endpackage
 

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/Process.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/Process.ocl
@@ -68,9 +68,9 @@ context Process
     -- In general, at each hierarchy level within the Process section all names shall be
     -- unique, leading to unique object references (path names) of all objects defined by the
     -- substation naming hierarchy.
-    inv unique_name_same_level_in_Process
+    inv Process_unique_name_same_level
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_same_level_in_Process;'
+          + 'OCL/SemanticConstraints/Process_unique_name_same_level;'
           + self.lineNumber.toString() + ';'
           + 'All names shall be unique at each hierarchy level within the Process'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/ReportControl.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/ReportControl.ocl
@@ -41,9 +41,9 @@ context ReportControl
         
     -- confRev is "The configuration revision number of this report control block. 
     -- The value 0 is only allowed for a control block without data set reference."
-    inv conRef_zero_no_DataSet_reference
+    inv ReportControl_conRef_zero_no_DataSet_reference
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/conRef_zero_no_DataSet_reference;'
+          + 'OCL/SemanticConstraints/ReportControl_conRef_zero_no_DataSet_reference;'
           + self.lineNumber.toString() + ';'
           + 'confRev attribute in ReportControl equals zero only for no DataSet reference'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/SampledValueControl.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/SampledValueControl.ocl
@@ -39,9 +39,9 @@ context SampledValueControl
         self.datSet <> null implies self.ParentLN0.DataSet -> exists( d : DataSet | self.datSet = d.name )
         
     -- multicast = "false indicates Unicast SMV services only meaning that smvID = UsvID"
-    inv false_multicast
+    inv SampledValueControl_false_multicast
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/false_multicast;'
+          + 'OCL/SemanticConstraints/SampledValueControl_false_multicast;'
           + self.lineNumber.toString() + ';'
           + 'smvID = UsvID in SampledValueControl for multicast = false'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/SubEquipment.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/SubEquipment.ocl
@@ -50,9 +50,9 @@ context SubEquipment
         endif
         
     -- The SubEquipment in AbstractConductingEquipment shall have unique child name (from SCL_Substation.xsd)
-    inv unique_name_in_SubEquipment_from_AbstractConductingEquipment
+    inv SubEquipment_unique_name_in_SubEquipment_from_AbstractConductingEquipment
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_SubEquipment_from_AbstractConductingEquipment;'
+          + 'OCL/SemanticConstraints/SubEquipment_unique_name_from_AbstractConductingEquipment;'
           + self.lineNumber.toString() + ';'
           + 'Unique child name in SubEquipment from AbstractConductingEquipment'
         )
@@ -60,9 +60,9 @@ context SubEquipment
         self.oclContainer.oclIsKindOf(AbstractConductingEquipment) implies self.oclContents -> isUnique(n:Naming|n.name)
         
     -- The SubEquipment in PowerTransformer shall have unique child name (from SCL_Substation.xsd)
-    inv unique_name_in_SubEquipment_from_PowerTransformer
+    inv SubEquipment_unique_name_in_SubEquipment_from_PowerTransformer
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_SubEquipment_from_PowerTransformer;'
+          + 'OCL/SemanticConstraints/SubEquipment_unique_name_from_PowerTransformer;'
           + self.lineNumber.toString() + ';'
           + 'Unique child name in SubEquipment from PowerTransformer'
         )
@@ -70,9 +70,9 @@ context SubEquipment
         self.oclContainer.oclIsTypeOf(PowerTransformer) implies self.oclContents -> isUnique(n:Naming|n.name)
         
     -- The SubEquipment in TapChanger shall have unique child name (from SCL_Substation.xsd)
-    inv unique_name_in_SubEquipment_from_TapChanger
+    inv SubEquipment_unique_name_in_SubEquipment_from_TapChanger
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_SubEquipment_from_TapChanger;'
+          + 'OCL/SemanticConstraints/SubEquipment_unique_name_from_TapChanger;'
           + self.lineNumber.toString() + ';'
           + 'Unique child name in SubEquipment from TapChanger'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/SubEquipment.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/SubEquipment.ocl
@@ -49,36 +49,6 @@ context SubEquipment
             else true endif
         endif
         
-    -- The SubEquipment in AbstractConductingEquipment shall have unique child name (from SCL_Substation.xsd)
-    inv SubEquipment_unique_name_in_SubEquipment_from_AbstractConductingEquipment
-        (   'ERROR;'
-          + 'OCL/SemanticConstraints/SubEquipment_unique_name_from_AbstractConductingEquipment;'
-          + self.lineNumber.toString() + ';'
-          + 'Unique child name in SubEquipment from AbstractConductingEquipment'
-        )
-    :
-        self.oclContainer.oclIsKindOf(AbstractConductingEquipment) implies self.oclContents -> isUnique(n:Naming|n.name)
-        
-    -- The SubEquipment in PowerTransformer shall have unique child name (from SCL_Substation.xsd)
-    inv SubEquipment_unique_name_in_SubEquipment_from_PowerTransformer
-        (   'ERROR;'
-          + 'OCL/SemanticConstraints/SubEquipment_unique_name_from_PowerTransformer;'
-          + self.lineNumber.toString() + ';'
-          + 'Unique child name in SubEquipment from PowerTransformer'
-        )
-    :
-        self.oclContainer.oclIsTypeOf(PowerTransformer) implies self.oclContents -> isUnique(n:Naming|n.name)
-        
-    -- The SubEquipment in TapChanger shall have unique child name (from SCL_Substation.xsd)
-    inv SubEquipment_unique_name_in_SubEquipment_from_TapChanger
-        (   'ERROR;'
-          + 'OCL/SemanticConstraints/SubEquipment_unique_name_from_TapChanger;'
-          + self.lineNumber.toString() + ';'
-          + 'Unique child name in SubEquipment from TapChanger'
-        )
-    :
-        self.oclContainer.oclIsTypeOf(TapChanger) implies self.oclContents -> isUnique(n:Naming|n.name)
-
 
 endpackage
 

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/Substation.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/Substation.ocl
@@ -76,37 +76,6 @@ context Substation
         --in let childs_4 : OrderedSet( Naming ) = childs_3->union( self.VoltageLevel )
         --in childs_4->isUnique( n : Naming | n.name )
 
-    -- In general, at each hierarchy level within the substation section all
-    -- names shall be unique, leading to unique object
-    inv Substation_unique_name_same_level
-        (   'ERROR;'
-          + 'OCL/SemanticConstraints/Substation_unique_name_same_level;'
-          + self.lineNumber.toString() + ';'
-          + 'All names shall be unique at each hierarchy level within the Substation'
-        )
-    :   
-        if self.ParentSCL <> null then
-        SclObject.allInstances()->
-        select(s:SclObject|self.ParentSCL.oclContents()->
-            select(s:SclObject|s.lineNumber>self.lineNumber)->
-            forAll(s1:SclObject|s1.lineNumber>s.lineNumber) 
-            and s.lineNumber>self.lineNumber)->
-            select(s:SclObject|s.oclIsKindOf(Naming))->
-            exists(n1:Naming;n2:Naming|n1<>n2 
-                and n1.oclContainer=n2.oclContainer 
-                and n1.name=n2.name) implies false
-        else
-        SclObject.allInstances()->
-        select(s:SclObject|self.ParentProcess.oclContents()->
-            select(s:SclObject|s.lineNumber>self.lineNumber)->
-            forAll(s1:SclObject|s1.lineNumber>s.lineNumber) 
-            and s.lineNumber>self.lineNumber)->
-            select(s:SclObject|s.oclIsKindOf(Naming))->
-            exists(n1:Naming;n2:Naming|n1<>n2 
-                and n1.oclContainer=n2.oclContainer 
-                and n1.name=n2.name) implies false
-        endif
-        
     -- For a primary system template within an ICD file, the substation name
     -- shall be TEMPLATE. There can be a maximum of one substation template in one
     -- SCL file.
@@ -144,34 +113,6 @@ context Substation
 
     -- A logical node instance within an IED can only be referenced once within all substation sections.
     
-    inv Substation_unique_LN_reference_LNode
-        (   'ERROR;'
-          + 'OCL/SemanticConstraints/Substation_unique_LN_reference_LNode;'
-          + self.lineNumber.toString() + ';'
-          + 'LN reference from LNode element in Substation shall be unique in the Substation'
-        )
-        :
-        (if SCL.allInstances().Substation -> notEmpty() then SclObject.allInstances()->
-        select(s:SclObject|SCL.allInstances().oclContents()->
-            select(s:SclObject|s.lineNumber>(SCL.allInstances().Substation->
-                collect(s:Substation|s.lineNumber)->
-                max()))->
-                forAll(s1:SclObject|s1.lineNumber>s.lineNumber) and s.lineNumber>(SCL.allInstances().Substation->
-                    collect(s:Substation|s.lineNumber)->max()))->
-                    select(s:SclObject|s.oclIsKindOf(LNode))->
-                    select(l:LNode|l.RefersToAnyLN<>null)else null.oclAsSet() endif)->
-             union(if Process.allInstances() -> notEmpty() and Process.allInstances().Substation-> notEmpty() then SclObject.allInstances()->
-        select(s:SclObject|Process.allInstances().oclContents()->
-            select(s:SclObject|s.lineNumber>(Process.allInstances().Substation->
-                collect(s:Substation|s.lineNumber)->
-                max()))->
-                forAll(s1:SclObject|s1.lineNumber>s.lineNumber) and s.lineNumber>(Process.allInstances().Substation->
-                    collect(s:Substation|s.lineNumber)->max()))->
-                    select(s:SclObject|s.oclIsKindOf(LNode))->
-                    select(l:LNode|l.RefersToAnyLN<>null)else null.oclAsSet() endif) ->
-                        isUnique(l:LNode|l.RefersToAnyLN)
-        
-
     
 
 endpackage

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/Substation.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/Substation.ocl
@@ -78,9 +78,9 @@ context Substation
 
     -- In general, at each hierarchy level within the substation section all
     -- names shall be unique, leading to unique object
-    inv unique_name_same_level_in_Substation
+    inv Substation_unique_name_same_level
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_same_level_in_Substation;'
+          + 'OCL/SemanticConstraints/Substation_unique_name_same_level;'
           + self.lineNumber.toString() + ';'
           + 'All names shall be unique at each hierarchy level within the Substation'
         )
@@ -130,9 +130,9 @@ context Substation
     
     -- Substation terminals shall not reference connectivity nodes inside Line elements
     
-    inv Terminal_CNode_not_refererences_Line_CNode
+    inv Substation_Terminal_CNode_not_refererences_Line_CNode
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/Terminal_CNode_not_refererences_Line_CNode;'
+          + 'OCL/SemanticConstraints/Substation_Terminal_CNode_not_refererences_Line_CNode;'
           + self.lineNumber.toString() + ';'
           + 'ConnectivityNode from Terminal shall not reference a ConnectivityNode from Line'
         )
@@ -144,9 +144,9 @@ context Substation
 
     -- A logical node instance within an IED can only be referenced once within all substation sections.
     
-    inv unique_LN_reference_in_Substation_LNode
+    inv Substation_unique_LN_reference_LNode
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_LN_reference_in_Substation_LNode;'
+          + 'OCL/SemanticConstraints/Substation_unique_LN_reference_LNode;'
           + self.lineNumber.toString() + ';'
           + 'LN reference from LNode element in Substation shall be unique in the Substation'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/TapChanger.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/TapChanger.ocl
@@ -25,16 +25,6 @@ package scl
 
 context TapChanger
         
-    -- The TapChanger in TransformerWinding shall have unique child name (from SCL_Substation.xsd)
-    inv TapChanger_unique_name_from_TransformerWinding
-        (   'ERROR;'
-          + 'OCL/SemanticConstraints/TapChanger_unique_name_from_TransformerWinding;'
-          + self.lineNumber.toString() + ';'
-          + 'Unique child name in TapChanger from TransformerWinding'
-        )
-    :
-        self.oclContainer.oclIsTypeOf(TransformerWinding) implies self.oclContents -> isUnique(n:Naming|n.name)
-
     -- The SubEquipment in TapChanger shall have unique child name (from SCL_Substation.xsd)
     inv TapChanger_unique_name_of_SubEquipment
         (   'ERROR;'

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/TapChanger.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/TapChanger.ocl
@@ -26,9 +26,9 @@ package scl
 context TapChanger
         
     -- The TapChanger in TransformerWinding shall have unique child name (from SCL_Substation.xsd)
-    inv unique_name_in_TapChanger_from_TransformerWinding
+    inv TapChanger_unique_name_from_TransformerWinding
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_TapChanger_from_TransformerWinding;'
+          + 'OCL/SemanticConstraints/TapChanger_unique_name_from_TransformerWinding;'
           + self.lineNumber.toString() + ';'
           + 'Unique child name in TapChanger from TransformerWinding'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/TapChanger.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/TapChanger.ocl
@@ -35,5 +35,15 @@ context TapChanger
     :
         self.oclContainer.oclIsTypeOf(TransformerWinding) implies self.oclContents -> isUnique(n:Naming|n.name)
 
+    -- The SubEquipment in TapChanger shall have unique child name (from SCL_Substation.xsd)
+    inv TapChanger_unique_name_of_SubEquipment
+        (   'ERROR;'
+          + 'OCL/SemanticConstraints/TapChanger_unique_name_of_SubEquipment;'
+          + self.lineNumber.toString() + ';'
+          + 'Unique child name of SubEquipment in TapChanger'
+        )
+    :
+        self.SubEquipment -> isUnique( n : Naming | n.name )
+
 endpackage
 

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/TransformerWinding.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/TransformerWinding.ocl
@@ -26,9 +26,9 @@ package scl
 context TransformerWinding
 
     -- The TransformerWinding in PowerTransformer shall have unique name in SubEquipment, TapChanger, EqFunction (from SCL_Substation.xsd)
-    inv unique_name_in_SubEquipment
+    inv TransformerWinding_unique_name_in_SubEquipment
         (   'ERROR;'
-          + 'OCL/SemanticConstraints/unique_name_in_SubEquipment;'
+          + 'OCL/SemanticConstraints/TransformerWinding_unique_name_in_SubEquipment;'
           + self.lineNumber.toString() + ';'
           + 'Unique SubEquipment, TapChanger, EqFunction name in SubEquipment from AbstractConductingEquipment'
         )

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/TransformerWinding.ocl
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.ocl/SemanticConstraints/TransformerWinding.ocl
@@ -36,5 +36,15 @@ context TransformerWinding
         self.oclContainer.oclIsTypeOf(PowerTransformer) implies 
         self.SubEquipment -> union(self.TapChanger -> union(self.EqFunction)) -> isUnique(n:Naming|n.name)
 
+    -- The TapChanger in TransformerWinding shall have unique child name (from SCL_Substation.xsd)
+    inv TransformerWinding_unique_name_of_TapChanger
+        (   'ERROR;'
+          + 'OCL/SemanticConstraints/TransformerWinding_unique_name_of_TapChanger;'
+          + self.lineNumber.toString() + ';'
+          + 'Unique child name of TapChanger in TransformerWinding'
+        )
+    :
+        self.TapChanger -> isUnique( n : Naming | n.name )
+
 endpackage
 


### PR DESCRIPTION
Those warnings were displayed when the OCL files were opened in Eclipse.
It may be relevant to look at each commit and comment on it if needed (some constraints were removed without any replacement)